### PR TITLE
Add transformer text classification and generation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,21 @@ python Jour21/cnn_chien_chat.py
 ```
 
 Le script télécharge automatiquement le jeu de données, construit un CNN simple puis lance l'entraînement et l'évaluation.
+
+## Classification et génération de texte
+
+Le fichier `transformers_text.py` montre comment utiliser la bibliothèque `transformers` de Hugging Face pour faire de la classification de texte et de la génération de texte.
+
+Installez d'abord la bibliothèque :
+
+```bash
+pip install transformers
+```
+
+Puis lancez le script :
+
+```bash
+python transformers_text.py
+```
+
+Les modèles pré-entraînés seront téléchargés lors de la première exécution.

--- a/transformers_text.py
+++ b/transformers_text.py
@@ -1,0 +1,22 @@
+from transformers import pipeline
+
+
+def classify_text(texts, model_name="distilbert-base-uncased-finetuned-sst-2-english"):
+    """Return sentiment predictions for a list of texts."""
+    classifier = pipeline("sentiment-analysis", model=model_name)
+    return classifier(texts)
+
+
+def generate_text(prompt, model_name="gpt2", max_length=50):
+    """Generate text continuation from a prompt."""
+    generator = pipeline("text-generation", model=model_name)
+    output = generator(prompt, max_length=max_length, num_return_sequences=1)[0]
+    return output["generated_text"]
+
+
+if __name__ == "__main__":
+    sample_texts = ["J'adore les modèles Transformers", "Je n'aime pas la pluie."]
+    print(classify_text(sample_texts))
+
+    prompt = "C'était une belle journée,"
+    print(generate_text(prompt))


### PR DESCRIPTION
## Summary
- add `transformers_text.py` with example functions for classification and generation
- document how to run the new script in README

## Testing
- `git status --short`